### PR TITLE
Fix duplicated baseband string on all devices.

### DIFF
--- a/src/com/android/settings/deviceinfo/firmwareversion/BasebandVersionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/BasebandVersionPreferenceController.java
@@ -43,17 +43,14 @@ public class BasebandVersionPreferenceController extends BasePreferenceControlle
 
     @Override
     public CharSequence getSummary() {
-        if (Utils.isSupportCTPA(mContext.getApplicationContext())) {
-            String baseBands = SystemProperties.get(BASEBAND_PROPERTY,
-                    mContext.getString(R.string.device_info_default));
-            if (null != baseBands) {
-                String[] baseBandArray = baseBands.split(",");
-                if ((baseBandArray != null) && (baseBandArray.length > 0)) {
-                    return baseBandArray[0];
-                }
+        String baseBands = SystemProperties.get(BASEBAND_PROPERTY,
+                mContext.getString(R.string.device_info_default));
+        if (null != baseBands) {
+            String[] baseBandArray = baseBands.split(",");
+            if ((baseBandArray != null) && (baseBandArray.length > 0)) {
+                return baseBandArray[0];
             }
         }
-        return SystemProperties.get(BASEBAND_PROPERTY,
-                mContext.getString(R.string.device_info_default));
+        return baseBands;
     }
 }


### PR DESCRIPTION
 * CAF has fixed this year-old glitch but it seems like
   only a certain "CT PA" requires it and hence the code
   is guarded (check 4bb2825836dd5099447508d3cb321952e1f7a5fa
   and a7162edd8e811a1918f66769111f8cbda3a993fe)

 * Let's make the fix available for all dual SIM devices!

Change-Id: Icfc1e54047a0ecc4b52999c798d2e6a580309e46